### PR TITLE
Raid show organize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,5 @@ group :development, :test do
 end
 
 gem 'simple_calendar', '~> 2.0'
+
+gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,10 @@ GEM
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
     rails-assets-tether (1.4.7)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -264,6 +268,7 @@ DEPENDENCIES
   puma (~> 3.12)
   rails (~> 5.2.3)
   rails-assets-tether (>= 1.3.3)!
+  rails-controller-testing
   rake (= 13.0.1)
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)

--- a/app/controllers/raids_controller.rb
+++ b/app/controllers/raids_controller.rb
@@ -9,7 +9,6 @@ class RaidsController < ApplicationController
   def show
     @raid = raid
     @organized_signups = organized_signups
-    @test_array = test_array
     @signup = Signup.new
   end
 
@@ -51,14 +50,6 @@ class RaidsController < ApplicationController
     if current_user.admin != true
       redirect_to root_path, alert: 'You do not have the privileges required to do that.'
     end
-  end
-
-  def test_array
-    sub_ary1 = [1, 2, 3]
-    sub_ary2 = ['a', 'b', 'c']
-    sub_ary3 = sub_ary1 + sub_ary2
-    test_array = [sub_ary1, sub_ary2, sub_ary3]
-    return test_array
   end
 
   def organized_signups

--- a/app/controllers/raids_controller.rb
+++ b/app/controllers/raids_controller.rb
@@ -8,6 +8,8 @@ class RaidsController < ApplicationController
 
   def show
     @raid = raid
+    @organized_signups = organized_signups
+    @test_array = test_array
     @signup = Signup.new
   end
 
@@ -49,5 +51,133 @@ class RaidsController < ApplicationController
     if current_user.admin != true
       redirect_to root_path, alert: 'You do not have the privileges required to do that.'
     end
+  end
+
+  def test_array
+    sub_ary1 = [1, 2, 3]
+    sub_ary2 = ['a', 'b', 'c']
+    sub_ary3 = sub_ary1 + sub_ary2
+    test_array = [sub_ary1, sub_ary2, sub_ary3]
+    return test_array
+  end
+
+  def organized_signups
+    tanks = []
+    healing_priests = []
+    healing_shamans = []
+    healing_druids = []
+    dps_warriors = []
+    rogues = []
+    ferals = []
+    enhancements = []
+    hunters = []
+    mages = []
+    warlocks = []
+    shadows = []
+    moonkins = []
+    elementals = []
+    zg_healer_standbys = []
+    zg_dps_standbys = []
+    healers_count = 0
+    damage_dealers = 0
+    signups = Signup.where(raid_id: raid)
+    if raid.zg?  
+      signups.each do |signup|
+        raider = Raider.find(signup.user.raider_id)
+
+        if raider.name == 'Ezpzlul' && tanks.count < 2
+          tanks << signup
+          next
+        elsif raider.role == 'Tank' && tanks.count < 2
+          tanks << signup
+          next
+        elsif  raider.role == 'Tank' && tanks.count >= 2 && damage_dealers < 13
+          dps_warriors << signup
+          damage_dealers += 1
+          next
+        elsif raider.role == 'Healer' && healers_count < 5
+          healing_priests << signup if raider.which_class == 'Priest'
+          healing_shamans << signup if raider.which_class == 'Shaman' 
+          healing_druids << signup if raider.which_class == 'Druid'
+          healers_count += 1
+          next
+        elsif raider.role == 'Healer' && healers_count >= 5
+          zg_healer_standbys << signup
+          healers_count += 1
+          next
+        elsif damage_dealers >= 13
+          zg_dps_standbys << signup
+          damage_dealers += 1
+          next
+        elsif raider.role == 'Fury'
+          dps_warriors << signup 
+          damage_dealers += 1
+          next
+        elsif raider.which_class == 'Rogue'
+          rogues << signup 
+          damage_dealers += 1
+          next
+        elsif raider.role == 'Feral'
+          ferals << signup
+          damage_dealers += 1
+          next
+        elsif raider.role == 'Enhancement'
+          enhancements << signup
+          damage_dealers += 1
+          next
+        elsif raider.which_class == 'Hunter'
+          hunters << signup 
+          damage_dealers += 1
+          next
+        elsif raider.which_class == 'Mage'
+          mages << signup
+          damage_dealers += 1
+          next
+        elsif raider.which_class == 'Warlock'  
+          warlocks << signup
+          damage_dealers += 1
+          next
+        elsif raider.role == 'Shadow'
+          shadows << signup
+          damage_dealers += 1
+          next
+        elsif raider.role == 'Moonkin'
+          moonkins << signup
+          damage_dealers += 1
+          next
+        elsif raider.role == 'Elemental'
+          elementals << signup
+          damage_dealers += 1
+          next
+        else 
+          next
+        end
+      end
+    else
+      signups.each do |signup|
+        raider = Raider.find(signup.user.raider_id)
+
+        tanks << signup if raider.role == 'Tank'
+        healing_priests << signup if raider.role == 'Healer' && raider.which_class == 'Priest'
+        healing_shamans << signup if raider.role == 'Healer' && raider.which_class == 'Shaman'
+        healing_druids << signup if raider.role == 'Healer' && raider.which_class == 'Druid'
+        dps_warriors << signup if raider.role == 'Fury'
+        rogues << signup if raider.which_class == 'Rogue'
+        ferals << signup if raider.role == 'Feral'
+        enhancements << signup if raider.role == 'Enhancement'
+        hunters << signup if raider.which_class == 'Hunter'
+        mages << signup if raider.which_class == 'Mage'
+        warlocks << signup if raider.which_class == 'Warlock'
+        shadows << signup if raider.role == 'Shadow'
+        moonkins << signup if raider.role == 'Moonkin'
+        elementals << signup if raider.role == 'Elemental'
+        next
+      end
+    end
+    healers = healing_priests + healing_shamans + healing_druids
+    melee = dps_warriors + rogues + ferals + enhancements
+    ranged = hunters + mages + warlocks + shadows + moonkins + elementals
+    raid = [tanks, healers, melee, ranged, zg_healer_standbys, zg_dps_standbys]
+    return raid
   end
 end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -33,7 +33,7 @@ class SignupsController < ApplicationController
     open_time = start_time - 7.days
     time_till_raid = start_time - Time.now
     if time_till_raid > 604800 
-      redirect_to raid_path(raid), alert: "You can not currently sign up for this raid. Sign ups open #{open_time.strftime("%B %-d, %Y %l:%M %p")}"
+      redirect_to raid_path(raid), alert: "You can not currently sign up for this raid. Sign ups open #{open_time.strftime("%B %-d, %Y %l:%M %p")} EST."
     end
     if time_till_raid < 0
       redirect_to raid_path(raid), alert: 'You can not sign up for raids that have already occured.'

--- a/app/models/raid.rb
+++ b/app/models/raid.rb
@@ -1,62 +1,32 @@
 class Raid < ApplicationRecord
   has_many :signups, dependent: :destroy
 
-  def signed_up_tanks
-    signed_up_tanks = []
-    self.signups.each do |signup|
-      signed_up_tanks << signup if signup.user.raider.role == 'Tank'
-      next
-    end
-    return signed_up_tanks
-  end
-
-  def signed_up_healers
-    priests = []
-    shamans = []
-    druids = []
-    self.signups.each do |signup|
-      priests << signup if signup.user.raider.which_class == 'Priest' && signup.user.raider.role == 'Healer' 
-      shamans << signup if signup.user.raider.which_class == 'Shaman' && signup.user.raider.role == 'Healer' 
-      druids << signup if signup.user.raider.which_class == 'Druid' && signup.user.raider.role == 'Healer' 
-      next
-    end
-    return priests + shamans + druids
-  end
-
-  def signed_up_melee
-    fury_warriors = []
-    rogues = []
-    feral_druids = []
-    enhancement_shamans = []
-    self.signups.each do |signup|
-      fury_warriors << signup if signup.user.raider.role == 'Fury'
-      rogues << signup if signup.user.raider.which_class == 'Rogue'
-      feral_druids << signup if signup.user.raider.role == 'Feral'
-      enhancement_shamans << signup if signup.user.raider.role == 'Enhancement'
-      next
-    end
-    return fury_warriors + rogues + feral_druids + enhancement_shamans
-  end
-
-  def signed_up_ranged
-    hunters = []
-    mages = []
-    warlocks = []
-    shadow_priests = []
-    elemental_shamans = []
-    moonkin_druids = []
-    self.signups.each do |signup|
-      hunters << signup if signup.user.raider.which_class == 'Hunter'
-      mages << signup if signup.user.raider.which_class == 'Mage'
-      warlocks << signup if signup.user.raider.which_class == 'Warlock'
-      shadow_priests << signup if signup.user.raider.role == 'Shadow'
-      elemental_shamans << signup if signup.user.raider.role == 'Elemental'
-      moonkin_druids << signup if signup.user.raider.role == 'Moonkin'
-      next
-    end
-    return hunters + mages + warlocks + shadow_priests + elemental_shamans + moonkin_druids
+  def zg? 
+    name = self.name.downcase.split('')
+    return name.include? 'z' && 'g'
   end
   
-  validates :name, presence: true, length: {minimum: 2}
+  def organized_signups
+    tanks = []
+    healers = []
+    dps_warriors = []
+    rogues = []
+    ranged = []
+    raid_id = self.id
+    signups = Signup.where(raid_id: raid_id)
+    signups.each do |signup|
+      tanks << signup if signup.user.raider.name == 'Ezpzlul' && tanks.count <= 2 && self.zg?
+      tanks << signup if signup.user.raider.role == 'Tank' && tanks.count <= 2 && self.zg?
+      tanks << signup if signup.user.raider.role == 'Tank'
+      healers << signup if signup.user.raider.role == 'Healer' && healers.count <= 5 && self.zg?
+      healers << signup if signup.user.raider.role == 'Healer'
+      next
+    end
+    melee = dps_warriors + rogues
+    raid = [tanks, healers, melee, ranged]
+    return raid
+  end
+
+  validates :name, presence: true, length: {minimum: 2, maximum: 25}
   validates :start_time, presence: true
 end

--- a/app/models/raid.rb
+++ b/app/models/raid.rb
@@ -3,7 +3,11 @@ class Raid < ApplicationRecord
 
   def zg? 
     name = self.name.downcase.split('')
-    return name.include? 'z' && 'g'
+    if name.include? 'z'
+      return true if name.include? 'g'
+      return false
+    end
+    return false
   end
   
   def organized_signups

--- a/app/models/raid.rb
+++ b/app/models/raid.rb
@@ -10,27 +10,6 @@ class Raid < ApplicationRecord
     return false
   end
   
-  def organized_signups
-    tanks = []
-    healers = []
-    dps_warriors = []
-    rogues = []
-    ranged = []
-    raid_id = self.id
-    signups = Signup.where(raid_id: raid_id)
-    signups.each do |signup|
-      tanks << signup if signup.user.raider.name == 'Ezpzlul' && tanks.count <= 2 && self.zg?
-      tanks << signup if signup.user.raider.role == 'Tank' && tanks.count <= 2 && self.zg?
-      tanks << signup if signup.user.raider.role == 'Tank'
-      healers << signup if signup.user.raider.role == 'Healer' && healers.count <= 5 && self.zg?
-      healers << signup if signup.user.raider.role == 'Healer'
-      next
-    end
-    melee = dps_warriors + rogues
-    raid = [tanks, healers, melee, ranged]
-    return raid
-  end
-
   validates :name, presence: true, length: {minimum: 2, maximum: 25}
   validates :start_time, presence: true
 end

--- a/app/models/winner.rb
+++ b/app/models/winner.rb
@@ -2,4 +2,5 @@ class Winner < ApplicationRecord
   belongs_to :raider
   belongs_to :item
   
+  validates :raider_id, uniqueness: { scope: [:item_id] }
 end

--- a/app/views/raids/_forty_man_raid_signups.html.erb
+++ b/app/views/raids/_forty_man_raid_signups.html.erb
@@ -1,0 +1,56 @@
+<div class="row">
+  <div class="col-6">
+    <h3 class="underline">Tanks:</h3>
+    <% @organized_signups[0].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="col-6">
+    <h3 class="underline">Healers:</h3>
+    <% @organized_signups[1].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+<div class="row">
+  <div class="col-6">
+    <h3 class="underline">Melee:</h3>
+    <% @organized_signups[2].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="col-6">
+    <h3 class="underline">Ranged:</h3>
+    <% @organized_signups[3].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/raids/_zg_raid_signups.html.erb
+++ b/app/views/raids/_zg_raid_signups.html.erb
@@ -1,0 +1,84 @@
+<div class="row">
+  <div class="col-6">
+    <h3 class="underline">Tanks:</h3>
+    <% @organized_signups[0].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="col-6">
+    <h3 class="underline">Healers:</h3>
+    <% @organized_signups[1].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+<div class="row">
+  <div class="col-6">
+    <h3 class="underline">Melee:</h3>
+    <% @organized_signups[2].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="col-6">
+    <h3 class="underline">Ranged:</h3>
+    <% @organized_signups[3].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+<div class="row">
+  <div class="col-6">
+    <h3 class="underline">DPS Stand-Bys:</h3>
+    <% @organized_signups[4].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="col-6">
+    <h3 class="underline">Healer Stand-Bys:</h3>
+    <% @organized_signups[5].each do |signup| %>
+      <div class="row no-left-margin">
+        <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
+        <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
+        <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
+        <% if current_user && current_user == signup.user %>
+          <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/raids/show.html.erb
+++ b/app/views/raids/show.html.erb
@@ -13,7 +13,7 @@
   <div class="row">
     <div class="col-6">
       <h3 class="underline">Tanks:</h3>
-      <% @raid.signed_up_tanks.each do |signup| %>
+      <% @organized_signups[0].each do |signup| %>
         <div class="row no-left-margin">
           <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
           <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
@@ -26,7 +26,7 @@
     </div>
     <div class="col-6">
       <h3 class="underline">Healers:</h3>
-      <% @raid.signed_up_healers.each do |signup| %>
+      <% @organized_signups[1].each do |signup| %>
         <div class="row no-left-margin">
           <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
           <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
@@ -41,7 +41,7 @@
   <div class="row">
     <div class="col-6">
       <h3 class="underline">Melee:</h3>
-      <% @raid.signed_up_melee.each do |signup| %>
+      <% @organized_signups[2].each do |signup| %>
         <div class="row no-left-margin">
           <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
           <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
@@ -54,7 +54,7 @@
     </div>
     <div class="col-6">
       <h3 class="underline">Ranged:</h3>
-      <% @raid.signed_up_ranged.each do |signup| %>
+      <% @organized_signups[3].each do |signup| %>
         <div class="row no-left-margin">
           <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
           <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>

--- a/app/views/raids/show.html.erb
+++ b/app/views/raids/show.html.erb
@@ -10,71 +10,20 @@
       <%= render partial: 'signup_for_raid' %> 
     <% end %>
   </div>
-  <div class="row">
-    <div class="col-6">
-      <h3 class="underline">Tanks:</h3>
-      <% @organized_signups[0].each do |signup| %>
-        <div class="row no-left-margin">
-          <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
-          <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
-          <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
-          <% if current_user && current_user == signup.user %>
-            <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-    <div class="col-6">
-      <h3 class="underline">Healers:</h3>
-      <% @organized_signups[1].each do |signup| %>
-        <div class="row no-left-margin">
-          <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
-          <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
-          <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
-          <% if current_user && current_user == signup.user %>
-            <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-6">
-      <h3 class="underline">Melee:</h3>
-      <% @organized_signups[2].each do |signup| %>
-        <div class="row no-left-margin">
-          <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
-          <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
-          <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
-          <% if current_user && current_user == signup.user %>
-            <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-    <div class="col-6">
-      <h3 class="underline">Ranged:</h3>
-      <% @organized_signups[3].each do |signup| %>
-        <div class="row no-left-margin">
-          <h5 class="<%= signup.user.raider.class_color %>"><%= signup.user.raider.name %></h5>
-          <h5>&nbsp- <%= signup.created_at.strftime("%_m/%-d %-H:%M:%S") %></h5>
-          <h5>&nbsp&nbspNotes: <%= signup.notes %></h5>
-          <% if current_user && current_user == signup.user %>
-            <%= link_to 'X', raid_signup_path(id: signup.id, raid_id: @raid.id), method: :delete, data: {confirm: 'Are you sure you want remove this sign up?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  <br />
-  <hr class="grey">
+  <% if @raid.zg? %>
+    <%= render partial: 'zg_raid_signups' %>
+  <% else %>
+    <%= render partial: 'forty_man_raid_signups' %>
+  <% end %>
   <% if current_user.try(:admin?) %>
-        <div class="col-12">
-          <div class="row">
-            <%= render partial: 'edit_raid' %>
-            &nbsp &nbsp
-            <%= link_to 'Delete Raid', raid_path(@raid), method: :delete, data: {confirm: 'Are you sure you want to delete this raid?'}, class: 'btn btn-secondary' %>
-          </div>
-        </div> 
+    <br />
+    <hr class="grey">
+    <div class="col-12">
+      <div class="row">
+        <%= render partial: 'edit_raid' %>
+        &nbsp &nbsp
+        <%= link_to 'Delete Raid', raid_path(@raid), method: :delete, data: {confirm: 'Are you sure you want to delete this raid?'}, class: 'btn btn-secondary' %>
+      </div>
+    </div> 
   <% end %>
 </div>

--- a/spec/controllers/raids_controller_spec.rb
+++ b/spec/controllers/raids_controller_spec.rb
@@ -134,4 +134,99 @@ RSpec.describe RaidsController, type: :controller do
       expect(raid.name).to eq 'ZG'
     end
   end
+
+  describe 'raids#show action' do
+    it 'it organizes the raid' do
+      raid = FactoryBot.create(:raid, name: 'BWL')
+      raider = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Fury')
+      user = FactoryBot.create(:user, raider_id: raider.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user.id)
+      
+      get :show, params: { id: raid.id}
+      
+      expect(response).to have_http_status(:success)
+      expect(assigns(:raid)).to eq(raid)
+      expect(assigns(:organized_signups)[2].count).to eq 1
+    end
+
+    it 'In ZG 3rd tank becomes DPS 6th healer becomes standby' do
+      raid = FactoryBot.create(:raid, name: 'ZG - optionalz')
+      raider1 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider2 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider3 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider4 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider5 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider6 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider7 = FactoryBot.create(:raider, which_class: 'Priest', role: 'Healer')
+      raider8 = FactoryBot.create(:raider, which_class: 'Priest', role: 'Healer')
+      raider9 = FactoryBot.create(:raider, which_class: 'Druid', role: 'Healer')
+      user1 = FactoryBot.create(:user, raider_id: raider1.id)
+      user2 = FactoryBot.create(:user, raider_id: raider2.id)
+      user3 = FactoryBot.create(:user, raider_id: raider3.id)
+      user4 = FactoryBot.create(:user, raider_id: raider4.id)
+      user5 = FactoryBot.create(:user, raider_id: raider5.id)
+      user6 = FactoryBot.create(:user, raider_id: raider6.id)
+      user7 = FactoryBot.create(:user, raider_id: raider7.id)
+      user8 = FactoryBot.create(:user, raider_id: raider8.id)
+      user9 = FactoryBot.create(:user, raider_id: raider9.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user1.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user2.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user3.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user4.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user5.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user6.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user7.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user8.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user9.id)
+      
+      get :show, params: { id: raid.id}
+      
+      expect(response).to have_http_status(:success)
+      expect(assigns(:raid)).to eq(raid)
+      expect(assigns(:organized_signups)[0].count).to eq 2
+      expect(assigns(:organized_signups)[2].count).to eq 1
+      expect(assigns(:organized_signups)[1].count).to eq 5
+      expect(assigns(:organized_signups)[4].count).to eq 1
+    end
+
+    it 'In non ZG no limits to assignments' do
+      raid = FactoryBot.create(:raid, name: 'BWLzz')
+      raider1 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider2 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider3 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider4 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider5 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider6 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider7 = FactoryBot.create(:raider, which_class: 'Priest', role: 'Healer')
+      raider8 = FactoryBot.create(:raider, which_class: 'Priest', role: 'Healer')
+      raider9 = FactoryBot.create(:raider, which_class: 'Druid', role: 'Healer')
+      user1 = FactoryBot.create(:user, raider_id: raider1.id)
+      user2 = FactoryBot.create(:user, raider_id: raider2.id)
+      user3 = FactoryBot.create(:user, raider_id: raider3.id)
+      user4 = FactoryBot.create(:user, raider_id: raider4.id)
+      user5 = FactoryBot.create(:user, raider_id: raider5.id)
+      user6 = FactoryBot.create(:user, raider_id: raider6.id)
+      user7 = FactoryBot.create(:user, raider_id: raider7.id)
+      user8 = FactoryBot.create(:user, raider_id: raider8.id)
+      user9 = FactoryBot.create(:user, raider_id: raider9.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user1.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user2.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user3.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user4.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user5.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user6.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user7.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user8.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user9.id)
+      
+      get :show, params: { id: raid.id}
+      
+      expect(response).to have_http_status(:success)
+      expect(assigns(:raid)).to eq(raid)
+      expect(assigns(:organized_signups)[0].count).to eq 3
+      expect(assigns(:organized_signups)[2].count).to eq 0
+      expect(assigns(:organized_signups)[1].count).to eq 6
+      expect(assigns(:organized_signups)[4].count).to eq 0
+    end
+  end
 end

--- a/spec/controllers/raids_controller_spec.rb
+++ b/spec/controllers/raids_controller_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RaidsController, type: :controller do
     end
 
     it 'In non ZG no limits to assignments' do
-      raid = FactoryBot.create(:raid, name: 'BWLzz')
+      raid = FactoryBot.create(:raid, name: 'Another go')
       raider1 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
       raider2 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
       raider3 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')

--- a/spec/controllers/signups_controller_spec.rb
+++ b/spec/controllers/signups_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe SignupsController, type: :controller do
       post :create, params: {raid_id: raid.id, signup: {notes: 'Test'}}
       
       expect(response).to redirect_to raid_path(raid)
-      expect(flash[:alert]).to eq "You can not currently sign up for this raid. Sign ups open #{open_time.strftime("%B %-d, %Y %l:%M %p")}"
+      expect(flash[:alert]).to eq "You can not currently sign up for this raid. Sign ups open #{open_time.strftime("%B %-d, %Y %l:%M %p")} EST."
       expect(Signup.count).to eq 0
     end
 

--- a/spec/controllers/winners_controller_spec.rb
+++ b/spec/controllers/winners_controller_spec.rb
@@ -4,11 +4,14 @@ RSpec.describe WinnersController, type: :controller do
   describe 'winners#create action' do
     it 'allows winners to be created and updates total points spend by a raider' do
       raider = FactoryBot.create(:raider, total_points_spent: 0.6, total_points_earned: 5.0)
-      item = FactoryBot.create(:item)
+      item1 = FactoryBot.create(:item)
+      item2 = FactoryBot.create(:item)
+      winner1 = FactoryBot.create(:winner, raider: raider, item: item2, points_spent: 3.6)
+      winner2 = FactoryBot.create(:winner, item: item1, points_spent: 3.6)
       user = FactoryBot.create(:user, admin: true)
       sign_in user
       
-      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6}}
+      post :create, params: {item_id: item1.id, winner: {raider_id: raider.id, points_spent: 3.6}}
 
       expect(response).to redirect_to raider_path(raider)
       winner = Winner.last
@@ -44,6 +47,24 @@ RSpec.describe WinnersController, type: :controller do
       expect(response).to redirect_to root_path
       expect(flash[:alert]).to eq 'You do not have the privileges required to do that.'
       expect(Winner.count).to eq 0
+
+      raider.reload      
+      expect(raider.total_points_spent).to eq 0.6
+      expect(raider.total_points_earned).to eq 5.0
+    end
+
+    it 'raider can not win same item twice' do
+      raider = FactoryBot.create(:raider, total_points_spent: 0.6, total_points_earned: 5.0)
+      item = FactoryBot.create(:item)
+      winner = FactoryBot.create(:winner, raider: raider, item: item, points_spent: 3.6)
+      user = FactoryBot.create(:user, admin: true)
+      sign_in user
+      
+      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6}}
+
+      expect(response).to redirect_to item_path(item)
+      expect(flash[:alert]).to eq 'There was an error creating this.'
+      expect(Winner.count).to eq 1
 
       raider.reload      
       expect(raider.total_points_spent).to eq 0.6

--- a/spec/models/raid_spec.rb
+++ b/spec/models/raid_spec.rb
@@ -1,5 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe Raid, type: :model do
+  describe 'zg? method' do
+    it 'returns true for ZG' do
+      raid = FactoryBot.create(:raid, name: 'ZG')
 
+      expect(raid.zg?).to eq true
+    end
+
+    it 'returns false for ZAA' do
+      raid = FactoryBot.create(:raid, name: 'ZAA')
+
+      expect(raid.zg?).to eq false
+    end
+
+    it 'returns false for GAA' do
+      raid = FactoryBot.create(:raid, name: 'GAA')
+
+      expect(raid.zg?).to eq false
+    end
+  end
 end

--- a/spec/models/winner_spec.rb
+++ b/spec/models/winner_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Winner, type: :model do
+
+end


### PR DESCRIPTION
ZG raids now break off stand bys into separate categories.
1. Added private method that returns an array with 6 sub arrays. Iterate through each subarray on the show page of a raid to display signups in the proper sections.
2. Added gem to allow me to test assignments in Rspec.
Bug Fixes:
1. Clarified what time zone when signing up for a raid before the one week. 
2. Eliminated Horizontal rule showing up on raid show page for none admins.
3. Added a uniqueness validation for winners so a raider can only win an item once.