### PR TITLE
Phase5part2

### DIFF
--- a/add-attendances.rb
+++ b/add-attendances.rb
@@ -1,0 +1,4 @@
+seven_weeks_ago = Time.now - 49.days
+Raider.all.each do |raider|
+    Attendance.create(raider: raider, notes: 'Bulk Test', points: 4.0, created_at: seven_weeks_ago)
+end

--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -283,3 +283,89 @@ abbr {
   font-weight: 500;
   font-size: 60px;
 }
+
+/* The checkbox-container */
+.checkbox-container {
+  display: block;
+  position: relative;
+  padding-left: 35px;
+  margin-bottom: 5px;
+  margin-right: 5px;
+  cursor: pointer;
+  font-size: 18px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* Hide the browser's default checkbox */
+.checkbox-container input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+/* Create a custom checkbox */
+.checkmark {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 18px;
+  width: 18px;
+  background-color: #eee;
+}
+
+/* On mouse-over, add a grey background color */
+.checkbox-container:hover input ~ .checkmark {
+  background-color: #ccc;
+}
+
+/* When the checkbox is checked, add a blue background */
+.checkbox-container input:checked ~ .checkmark {
+  background-color: purple;
+}
+
+/* Create the checkmark/indicator (hidden when not checked) */
+.checkmark:after {
+  content: "";
+  position: absolute;
+  display: none;
+}
+
+/* Show the checkmark when checked */
+.checkbox-container input:checked ~ .checkmark:after {
+  display: block;
+}
+
+/* Style the checkmark/indicator */
+.checkbox-container .checkmark:after {
+  left: 9px;
+  top: 5px;
+  width: 5px;
+  height: 10px;
+  border: solid white;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.normal-cursor:hover {
+  cursor: default;
+}
+
+.non-navbar-list-items {
+  color: white;
+  font-size: 28px;
+  margin-right: 5px;
+  margin-left: 10px;
+  padding: 5px
+}
+
+.non-navbar-list-items-admin {
+  color: white;
+  font-size: 28px;
+}

--- a/app/assets/stylesheets/raiders.scss
+++ b/app/assets/stylesheets/raiders.scss
@@ -31,10 +31,3 @@
   width: 160%;
   margin-left: -30%;
 }
-
-.non-navbar-list-items {
-  color: white;
-  font-size: 28px;
-  margin-right: 5px;
-  margin-left: 10px;
-}

--- a/app/controllers/priorities_controller.rb
+++ b/app/controllers/priorities_controller.rb
@@ -1,6 +1,7 @@
 class PrioritiesController < ApplicationController
   before_action :authenticate_user!
   before_action :maximum_two_priorities_per_ranking, only: :create
+  before_action :can_add_items_to_list?, only: :create
   before_action :priority_is_locked?, only: :update
   before_action :valid_priority?, only: :update
   before_action :correct_permissions_to_delete_priority, only: :destroy
@@ -82,6 +83,15 @@ class PrioritiesController < ApplicationController
     elsif raider.priorities.where(ranking: ranking, phase: phase).count >= 2
       redirect_to raider_path(raider), alert: 'You have to many items at a priority. Try removing some items from line 25.'
     end 
+  end
+
+  def can_add_items_to_list?
+    raider_id = priority_params[:raider_id].to_i
+    raider = Raider.find(raider_id)
+    last_priority = raider.priorities.last
+    if last_priority && last_priority.locked && last_priority.phase != 3
+      redirect_to raider_path(raider), alert: 'You can not add items to a completed list.'
+    end
   end
 
   def priority_is_locked?

--- a/app/controllers/raiders_controller.rb
+++ b/app/controllers/raiders_controller.rb
@@ -1,6 +1,6 @@
 class RaidersController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :update]
-  before_action :authenticate_admin!, only: [:new, :create, :update]
+  before_action :authenticate_user!, only: [:new, :create, :update, :enchanted, :warlock]
+  before_action :authenticate_admin!, only: [:new, :create, :update, :enchanted, :warlock]
 
   def index
     @raiders = sorted_raiders_for_index
@@ -19,7 +19,6 @@ class RaidersController < ApplicationController
       @parameter = params[:search].downcase  
       @items = Item.all.where("lower(name) LIKE :search", search: "%#{@parameter}%")
     end 
-     
   end
 
   def new
@@ -44,6 +43,34 @@ class RaidersController < ApplicationController
     else
       redirect_to raider_path(@raider), alert: 'That update is invalid.'
     end
+  end
+
+  def enchanted
+    raider = Raider.find(params[:raider_id])
+    if raider.enchanted?
+      raider.write_attribute(:enchanted, false)
+      raider.save
+      raider.update_total_points_earned(-0.1)
+    else
+      raider.write_attribute(:enchanted, true)
+      raider.save
+      raider.update_total_points_earned(0.1)
+    end
+    redirect_to raider_path(raider)
+  end
+
+  def warlock
+    raider = Raider.find(params[:raider_id])
+    if raider.warlock?
+      raider.write_attribute(:warlock, false)
+      raider.save
+      raider.update_total_points_earned(-0.1)
+    else
+      raider.write_attribute(:warlock, true)
+      raider.save
+      raider.update_total_points_earned(0.1)
+    end
+    redirect_to raider_path(raider)
   end
 
   private

--- a/app/controllers/winners_controller.rb
+++ b/app/controllers/winners_controller.rb
@@ -33,7 +33,7 @@ class WinnersController < ApplicationController
   private
 
   def winner_params
-    params.require(:winner).permit(:raider_id, :points_spent)
+    params.require(:winner).permit(:raider_id, :points_spent, :priority_id)
   end
 
   def authenticate_admin!

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,18 @@ class Item < ApplicationRecord
     return zone == 'Blackwing Lair' || zone == 'Lord Kazzak' || zone == 'Azuregos' || zone == 'Molten Core' || zone == 'Onyxia'
   end
 
+  def unlimited?
+    return classification == 'Unlimited'
+  end
+  
+  def limited?
+    return classification == 'Limited'
+  end
+
+  def reserved?
+    return classification == 'Reserved'
+  end
+
   def primary_class?(raider)
     return true if priority.nil?
     return true if priority == ''
@@ -35,7 +47,7 @@ class Item < ApplicationRecord
     self.priorities.each do |priority|
       next if priority.phase != 5
       next if priority.raider.role == 'Retired'
-      next if self.won_this_item?(priority)
+      next if priority.winner
       priorities_that_have_not_won << priority
     end
     return priorities_that_have_not_won.sort { |a, b| b.phase_5_total_item_value_for_raider <=> a.phase_5_total_item_value_for_raider}

--- a/app/models/priority.rb
+++ b/app/models/priority.rb
@@ -1,6 +1,19 @@
 class Priority < ApplicationRecord
   belongs_to :raider
   belongs_to :item
+  has_one :winner
+  
+  def max_points
+    if ranking >= 48
+      return 3.6
+    elsif ranking <= 47 && ranking >= 45
+      return 2.0
+    elsif ranking <= 44 && ranking >= 42
+      return 0.8
+    else 
+      return 0
+    end
+  end
   
   def points_worth
     raider = self.raider
@@ -14,18 +27,6 @@ class Priority < ApplicationRecord
     end
   end
 
-  def max_points
-    if ranking >= 48
-      return 3.6
-    elsif ranking <= 47 && ranking >= 45
-      return 2.0
-    elsif ranking <= 44 && ranking >= 42
-      return 0.8
-    else 
-      return 0
-    end
-  end
-
   def phase_3_total_item_value_for_raider
     net_points = self.raider.net_points
     ranking = self.ranking
@@ -33,7 +34,7 @@ class Priority < ApplicationRecord
     if self.item.primary_class?(self.raider) then 
       item_value = ranking + net_points
     else
-      item_value = (ranking + net_points)/2
+      item_value = ((ranking + net_points)/2).round(2)
     end
     if self.item.zone == 'Blackwing Lair'
       return 0 if weeks_with_the_guild < 3
@@ -55,23 +56,43 @@ class Priority < ApplicationRecord
     if self.item.primary_class?(self.raider) then 
       item_value = ranking + net_points
     else
-      item_value = (ranking + net_points) * 0.75
+      item_value = ((ranking + net_points) * 0.75).round(2)
     end
     if self.item.zone == 'Temple of Ahn\'Qiraj'
-      return 0 if weeks_with_the_guild < 4
-      return item_value - 3 if weeks_with_the_guild < 5
-      return item_value - 1 if weeks_with_the_guild < 6
-      return item_value
+      if self.item.unlimited?  
+        return 0 if weeks_with_the_guild < 3
+        return item_value - 3 if weeks_with_the_guild < 4
+        return item_value - 1 if weeks_with_the_guild < 5
+        return item_value
+      else
+        return 0 if weeks_with_the_guild < 4
+        return item_value - 2 if weeks_with_the_guild < 5
+        return item_value - 1 if weeks_with_the_guild < 6
+        return item_value
+      end
     elsif self.item.zone == 'Blackwing Lair'
-      return 0 if weeks_with_the_guild < 3
-      return item_value - 3 if weeks_with_the_guild < 4
-      return item_value - 1 if weeks_with_the_guild < 5
-      return item_value
+      if self.item.unlimited?  
+        return 0 if weeks_with_the_guild < 2
+        return item_value - 3 if weeks_with_the_guild < 3
+        return item_value - 1 if weeks_with_the_guild < 4
+        return item_value
+      else
+        return 0 if weeks_with_the_guild < 3
+        return item_value - 2 if weeks_with_the_guild < 4
+        return item_value - 1 if weeks_with_the_guild < 5
+        return item_value
+      end
     else
-      return 0 if weeks_with_the_guild < 2
-      return item_value - 3 if weeks_with_the_guild < 3
-      return item_value - 1 if weeks_with_the_guild < 4
-      return item_value
+      if self.item.unlimited?  
+        return item_value - 3 if weeks_with_the_guild < 2
+        return item_value - 1 if weeks_with_the_guild < 3
+        return item_value
+      else
+        return 0 if weeks_with_the_guild < 2
+        return item_value - 2 if weeks_with_the_guild < 3
+        return item_value - 1 if weeks_with_the_guild < 4
+        return item_value
+      end
     end 
   end
 

--- a/app/models/priority.rb
+++ b/app/models/priority.rb
@@ -18,12 +18,43 @@ class Priority < ApplicationRecord
   def points_worth
     raider = self.raider
     net_points = raider.net_points
-    if max_points >= net_points
-      return net_points
-    elsif max_points < net_points
-      return max_points
-    else 
-      return 0
+    # if max_points >= net_points
+    #   if raider.enchanted? && raider.warlock?
+    #     return (net_points - 0.2).round(2)
+    #   elsif raider.enchanted? || raider.warlock?
+    #     return(net_points -0.1).round(2)
+    #   else
+    #     return net_points.round(2)
+    #   end
+    # elsif max_points < net_points
+    #   return max_points.round(2)
+    # else 
+    #   return 0
+    # end
+    if raider.enchanted? && raider.warlock?
+      if max_points >= (net_points - 0.2).round(2)
+        return (net_points - 0.2).round(2)
+      elsif max_points < (net_points - 0.2)
+        return max_points.round(2)
+      else
+        return 0
+      end
+    elsif raider.enchanted? || raider.warlock?
+      if max_points >= (net_points - 0.1).round(2)
+        return (net_points - 0.1).round(2)
+      elsif max_points < (net_points - 0.1)
+        return max_points.round(2)
+      else
+        return 0
+      end
+    else
+      if max_points >= net_points
+        return net_points.round(2)
+      elsif max_points < net_points
+        return max_points.round(2)
+      else
+        return 0
+      end
     end
   end
 

--- a/app/models/winner.rb
+++ b/app/models/winner.rb
@@ -1,6 +1,7 @@
 class Winner < ApplicationRecord
   belongs_to :raider
   belongs_to :item
+  belongs_to :priority, optional: true 
   
-  validates :raider_id, uniqueness: { scope: [:item_id] }
+  validates :raider_id, uniqueness: { scope: [:priority_id] }
 end

--- a/app/views/attendances/index.html.erb
+++ b/app/views/attendances/index.html.erb
@@ -10,14 +10,16 @@
   <br>
   <ol>
     <% @attendances.order(created_at: :desc).each do |attendance| %>
-      <div class="row no-left-margin">
-        <li class="non-navbar-list-items">  
-            <%= attendance.notes %> - <%= attendance.points %>
-            <% if current_user.try(:admin?) %>
-              <%= link_to 'X', raider_attendance_path(raider_id: attendance.raider_id, id: attendance.id), method: :delete, data: {confirm: 'Are you sure you want delete this?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
-            <% end %>
+      <% if current_user.try(:admin?) %>
+        <li class="non-navbar-list-items-admin"> 
+        <%= attendance.notes %> - <%= attendance.points %>
+        <%= link_to 'X', raider_attendance_path(raider_id: attendance.raider_id, id: attendance.id), method: :delete, data: {confirm: 'Are you sure you want delete this?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
         </li>
-      </div>
+      <% else %>
+        <li class="non-navbar-list-items">  
+        <%= attendance.notes %> - <%= attendance.points %>
+        </li>
+      <% end %>
     <% end %>
   </ol>
   <h3>Points earned: <%= @raider.total_points_earned %></h3>

--- a/app/views/items/_free_roll_other_raiders.html.erb
+++ b/app/views/items/_free_roll_other_raiders.html.erb
@@ -21,7 +21,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>
@@ -35,7 +35,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>
@@ -49,7 +49,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>
@@ -63,7 +63,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>
@@ -77,7 +77,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>
@@ -91,7 +91,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>
@@ -105,7 +105,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>
@@ -119,7 +119,7 @@
 
               <% else %>
                 <div class="col-4">
-                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+                  <button data-raider-id="<%= raider.id %>" data-raider-name="<%= raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="nil" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
                     <%= raider.name %> - Free Roll
                   </button>
                 </div>

--- a/app/views/items/_p3_ordered_list_of_priorities.html.erb
+++ b/app/views/items/_p3_ordered_list_of_priorities.html.erb
@@ -13,12 +13,12 @@
     <% end %>
     <% if current_user.try(:admin?) %>
       <div class="col-3">
-        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= priority.points_worth %>" class="btn btn-secondary create-winner btn-sm">
+        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="<%= priority.id %>" data-points-spent="<%= priority.points_worth %>" class="btn btn-secondary create-winner btn-sm">
           <%= priority.raider.name %> - <%= priority.points_worth.to_s %>
         </button>
       </div>
       <div class="col-3">
-        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="<%= priority.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
           <%= priority.raider.name %> - Free Roll
         </button>
       </div>

--- a/app/views/items/_p5_ordered_list_of_priorities.html.erb
+++ b/app/views/items/_p5_ordered_list_of_priorities.html.erb
@@ -9,12 +9,12 @@
     <div class="col-3"><h5><%= link_to priority.raider.name, raider_path(priority.raider_id) %> - <%= priority.phase_5_total_item_value_for_raider %></h5></div>
     <% if current_user.try(:admin?) %>
       <div class="col-3">
-        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= priority.points_worth %>" class="btn btn-secondary create-winner btn-sm">
+        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="<%= priority.id %>" data-points-spent="<%= priority.points_worth %>" class="btn btn-secondary create-winner btn-sm">
           <%= priority.raider.name %> - <%= priority.points_worth.to_s %>
         </button>
       </div>
       <div class="col-3">
-        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
+        <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="<%= priority.id %>" data-points-spent="<%= 0 %>" class="btn btn-secondary create-winner btn-sm">
           <%= priority.raider.name %> - Free Roll
         </button>
       </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -52,13 +52,15 @@
     var points_spent = $(this).data('points-spent');
     var item = $(this).data('item-id');
     var raider = $(this).data('raider-id');
+    var priority = $(this).data('priority-id');
     var raider_name = $(this).data('raider-name');
     var url = `/items/${item}/winners`;
     var payload = {
       winner: {
         points_spent: points_spent,
         item_id: item,
-        raider_id: raider
+        raider_id: raider,
+        priority_id: priority
       }};
     $.ajax({
       type: "POST",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
       
       <%= form_tag(search_page_path, :method => "get", class: 'navbar-form navbar-left') do %>  
       <div class="input-group">  
-        <%= search_field_tag :search, params[:search], placeholder: "Search", class: "form-control" %>  
+        <%= search_field_tag :search, params[:search], placeholder: "Search", id: "navbar-search", class: "form-control" %>  
         <div class="input-group-btn">  
           <%= button_tag "Search", :class => 'btn btn-primary',:name => nil%>  
         </div>  

--- a/app/views/raiders/_aq_list.html.erb
+++ b/app/views/raiders/_aq_list.html.erb
@@ -73,7 +73,7 @@
             <div class="col-5 spot" data-ranking=<%= x %>>
               <div class="row phase-five-priority" data-priority-id=<%= priority.id %> data-item-id=<%= priority.item_id %>>
                 <h5 class="scoot-right <%= item_classification(priority) %>"><%= priority.item.name %></h5>
-                <% if current_user.try(:admin?) %>
+                <% if current_user && current_user.raider.id == @raider.id && !list_is_locked?(@raider) || current_user.try(:admin?) %>
                   <%= link_to 'X', item_priority_path(item_id: priority.item_id, priority_id: priority.id), method: :delete, data: {confirm: 'Are you sure you want delete this?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
                 <% end %>
               </div>
@@ -87,7 +87,7 @@
             <div class="col-5 spot" data-ranking=<%= x %>>
               <div class="row phase-five-priority" data-priority-id=<%= priority.id %> data-item-id=<%= priority.item_id %>>
                 <h5 class="scoot-right <%= item_classification(priority) %>"><%= priority.item.name %></h5>
-                <% if current_user.try(:admin?) %>
+                <% if current_user && current_user.raider.id == @raider.id && !list_is_locked?(@raider) || current_user.try(:admin?) %>
                   <%= link_to 'X', item_priority_path(item_id: priority.item_id, priority_id: priority.id), method: :delete, data: {confirm: 'Are you sure you want delete this?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
                 <% end %>
               </div>

--- a/app/views/raiders/show.html.erb
+++ b/app/views/raiders/show.html.erb
@@ -1,6 +1,6 @@
 <div class="box col-10 offset-1">
   <div class="row no-left-margin">
-    <div class="col-9">  
+    <div class="col-7">  
       <div class="row">  
         <h3 class="<%= @raider.class_color %>">
           <%= @raider.name %>
@@ -11,12 +11,68 @@
         </h3>
       </div>
     </div>
+    <% if current_user.try(:admin?) %>
+    <div class="col-2">
+      <div class="row">
+        <%= link_to raiders_enchanted_path(raider_id: @raider) do %>
+          <% if @raider.enchanted? %>
+            <label class="checkbox-container"> :Enchanted
+              <input type="checkbox" checked="checked">
+              <span class="checkmark"></span>
+            </label>
+          <% else %>
+            <label class="checkbox-container"> :Enchanted
+              <input type="checkbox">
+              <span class="checkmark"></span>
+            </label>
+          <% end %>
+        <% end %>
+        <%= link_to raiders_warlock_path(raider_id: @raider) do %>
+          <% if @raider.warlock? %>
+            <label class="checkbox-container"> :Warlock
+              <input type="checkbox" checked="checked">
+              <span class="checkmark"></span>
+            </label>
+          <% else %>
+            <label class="checkbox-container"> :Warlock
+              <input type="checkbox">
+              <span class="checkmark"></span>
+            </label>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
     <div class="col-3 text-right">  
-      <% if current_user.try(:admin?) %>
         <%= link_to 'No Call - No Show', raider_attendances_path(raider_id: @raider, attendance: {notes: 'No Call - No Show', points: -0.2}), method: :post, data: {confirm: 'Are you sure this raider did not post in attendance channel?'},class: 'btn btn-secondary' %>
         <%= render partial: 'edit_raider' %>
-      <% end %>
     </div>
+    <% else %>
+      <div class="col-3"></div>
+      <div class="col-2">
+        <% if @raider.enchanted? %>
+            <label class="checkbox-container normal-cursor"> :Enchanted
+              <input type="checkbox" checked="checked" disabled="true">
+              <span class="checkmark"></span>
+            </label>
+          <% else %>
+            <label class="checkbox-container normal-cursor"> :Enchanted
+              <input type="checkbox" disabled="true">
+              <span class="checkmark"></span>
+            </label>
+          <% end %>
+          <% if @raider.warlock? %>
+            <label class="checkbox-container normal-cursor"> :Warlock
+              <input type="checkbox" checked="checked" disabled="true">
+              <span class="checkmark"></span>
+            </label>
+          <% else %>
+            <label class="checkbox-container normal-cursor"> :Warlock
+              <input type="checkbox" disabled="true">
+              <span class="checkmark"></span>
+            </label>
+          <% end %>
+      </div>
+    <% end %>
   </div>
   <div class="row">
     <div class="col-4">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,7 +36,7 @@
   
   <hr class="grey"> 
   <h3 class="underline">Attendance</h3>
-    <div class="row no-left-margin"><h5>Raid Notes:</h5><input id="notes"></div>
+    <div class="row no-left-margin"><h5>Raid Notes:</h5><input id="notes">&nbsp <h5>Points Earned:</h5><input id="points"></div>
     <div class="row">
       <div class="col-4">
         <h4 class="underline">Warriors</h4>
@@ -44,17 +44,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="warrior"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -64,17 +55,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="rogue"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -86,17 +68,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="hunter"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -106,17 +79,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="mage"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -126,17 +90,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="warlock"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -148,17 +103,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="priest"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -168,17 +114,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="shaman"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -188,17 +125,8 @@
           <div class="row no-left-margin attendance-row">
             <div class="col-6 scoot-left"><h5 class="druid"><%= raider.name %></h5></div>
             <div class="col-6">
-              <button data-points="0.1" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.1
-              </button>
-              <button data-points="0.2" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.2
-              </button>
-              <button data-points="0.4" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.4
-              </button>
-              <button data-points="0.6" data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
-                0.6
+              <button data-id="<%= raider.id %>" data-name="<%= raider.name %>" type="button" class="btn btn-sm btn-points btn-secondary">
+                Add Attendance
               </button>
             </div>
           </div>
@@ -210,7 +138,7 @@
 
 <script type="text/javascript">
   $(".btn-secondary").click(function( event ) {
-    var points = $(this).data('points');
+    var points = $('#points').val();
     var notes = $('#notes').val()
     var raider = $(this).data('id');
     var raiderName = $(this).data('name');

--- a/app/views/winners/index.html.erb
+++ b/app/views/winners/index.html.erb
@@ -10,14 +10,16 @@
   <br>
   <ol>
     <% @winnings.order(created_at: :desc).each do |winner| %>
-      <div class="row no-left-margin">
-        <li class="non-navbar-list-items">  
-          <%= link_to winner.item.name, item_path(winner.item) %> - <%= winner.points_spent %>
-          <% if current_user.try(:admin?) %>
-            <%= link_to 'X', item_winner_path(item_id: winner.item_id, id: winner.id), method: :delete, data: {confirm: 'Are you sure you want delete this?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
-          <% end %>
+      <% if current_user.try(:admin?) %>
+        <li class="non-navbar-list-items-admin"> 
+        <%= link_to winner.item.name, item_path(winner.item) %> - <%= winner.points_spent %>
+        <%= link_to 'X', item_winner_path(item_id: winner.item_id, id: winner.id), method: :delete, data: {confirm: 'Are you sure you want delete this?'}, class: 'btn btn-sm scale-down btn-secondary scoot-right scoot-up' %>
         </li>
-      </div>
+      <% else %>
+        <li class="non-navbar-list-items">  
+        <%= link_to winner.item.name, item_path(winner.item) %> - <%= winner.points_spent %>
+        </li>
+      <% end %>
     <% end %>
   </ol>
   <h3>Points spent: <%= @raider.total_points_spent %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
   get '/users/:user_id/connect/:raider_id', to: 'users#connect'
   get '/search', to: 'pages#search', as: 'search_page'
   get '/raiders/:raider_id/search', to: 'raiders#search', as: 'raiders_search'
+  get '/raiders/:raider_id/enchanted', to: 'raiders#enchanted', as: 'raiders_enchanted'
+  get '/raiders/:raider_id/warlock', to: 'raiders#warlock', as: 'raiders_warlock'
   get '/calendar', to: 'pages#calendar'
   get '/zones/naxx', to: 'pages#naxx'
   get '/zones/aq', to: 'pages#aq'

--- a/db/migrate/20200719192758_add_enchanted_and_warlock_to_raider.rb
+++ b/db/migrate/20200719192758_add_enchanted_and_warlock_to_raider.rb
@@ -1,0 +1,6 @@
+class AddEnchantedAndWarlockToRaider < ActiveRecord::Migration[5.2]
+  def change
+    add_column :raiders, :enchanted, :boolean, null: false, default: false
+    add_column :raiders, :warlock, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20200719203425_add_priority_to_winners.rb
+++ b/db/migrate/20200719203425_add_priority_to_winners.rb
@@ -1,0 +1,5 @@
+class AddPriorityToWinners < ActiveRecord::Migration[5.2]
+  def change
+    add_column :winners, :priority_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_12_133350) do
+ActiveRecord::Schema.define(version: 2020_07_19_203425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,8 @@ ActiveRecord::Schema.define(version: 2020_07_12_133350) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.boolean "enchanted", default: false, null: false
+    t.boolean "warlock", default: false, null: false
   end
 
   create_table "raids", force: :cascade do |t|
@@ -114,6 +116,7 @@ ActiveRecord::Schema.define(version: 2020_07_12_133350) do
     t.integer "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "priority_id"
   end
 
 end

--- a/spec/controllers/priorities_controller_spec.rb
+++ b/spec/controllers/priorities_controller_spec.rb
@@ -335,4 +335,93 @@ RSpec.describe PrioritiesController, type: :controller do
       expect(priority3.locked).to eq true
     end
   end
+
+  describe 'priorities#destroy action' do
+    it 'destroys a phase 3 priority when user is admin' do
+      raider = FactoryBot.create(:raider)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 48, phase: 3, locked: true)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
+
+      delete :destroy, params: {use_route: "items/#{item.id}/priorities/", item_id: item.id, priority_id: priority.id}
+
+      expect(response).to redirect_to item_path(item)    
+
+      expect(Priority.count).to eq 0
+    end
+
+    it 'requires user to be signed in to delete priority' do
+      raider = FactoryBot.create(:raider)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 48, phase: 3, locked: true)
+      admin = FactoryBot.create(:user, admin: true)
+
+      delete :destroy, params: {use_route: "items/#{item.id}/priorities/", item_id: item.id, priority_id: priority.id}
+
+      expect(response).to redirect_to new_user_session_path
+   
+      expect(Priority.count).to eq 1
+    end
+
+    it 'User can delete their own unlocked phase 5 priority' do
+      non_admin = FactoryBot.create(:user, admin: false)
+      raider = FactoryBot.create(:raider, user: non_admin)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 48, phase: 5, locked: false)
+      sign_in non_admin
+
+      delete :destroy, params: {use_route: "items/#{item.id}/priorities/", item_id: item.id, priority_id: priority.id}
+
+      expect(response).to redirect_to raider_path(raider)
+
+      expect(Priority.count).to eq 0
+    end
+    
+    it 'requires admin to delete phase 3 priority' do
+      non_admin = FactoryBot.create(:user, admin: false)
+      raider = FactoryBot.create(:raider, user: non_admin)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 48, phase: 3, locked: false)
+      sign_in non_admin
+
+      delete :destroy, params: {use_route: "items/#{item.id}/priorities/", item_id: item.id, priority_id: priority.id}
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'You do not have the privileges required to do that.' 
+
+      expect(Priority.count).to eq 1
+    end
+
+    it 'requires admin to delete phase 5 locked priority' do
+      non_admin = FactoryBot.create(:user, admin: false)
+      raider = FactoryBot.create(:raider, user: non_admin)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 48, phase: 5, locked: true)
+      sign_in non_admin
+
+      delete :destroy, params: {use_route: "items/#{item.id}/priorities/", item_id: item.id, priority_id: priority.id}
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'You do not have the privileges required to do that.' 
+
+      expect(Priority.count).to eq 1
+    end
+
+    it 'User can not delete a different users unlocked phase 5 priority' do
+      other_user = FactoryBot.create(:user, admin: false)
+      raider = FactoryBot.create(:raider, user: other_user)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 48, phase: 5, locked: false)
+      non_admin = FactoryBot.create(:user, admin: false)
+      sign_in non_admin
+
+      delete :destroy, params: {use_route: "items/#{item.id}/priorities/", item_id: item.id, priority_id: priority.id}
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'You do not have the privileges required to do that.' 
+
+      expect(Priority.count).to eq 1
+    end
+  end
 end

--- a/spec/controllers/raiders_controller_spec.rb
+++ b/spec/controllers/raiders_controller_spec.rb
@@ -76,4 +76,120 @@ RSpec.describe RaidersController, type: :controller do
       expect(raider.role).to eq 'Fury'
     end
   end
+
+  describe 'raiders#enchanted action' do
+    it 'updates a non enchanted raider to true and grants 0.1 points earned' do
+      raider = FactoryBot.create(:raider, enchanted: false, total_points_earned: 0.4)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
+
+      get :enchanted, params: {use_route: "raiders/#{raider.id}/enchanted", raider_id: raider.id}
+
+      expect(response).to redirect_to raider_path(raider)
+
+      raider.reload
+      expect(raider.enchanted).to eq true
+      expect(raider.total_points_earned).to eq 0.5
+    end
+
+    it 'updates an enchanted raider to false and removes 0.1 points earned' do
+      raider = FactoryBot.create(:raider, enchanted: true, total_points_earned: 0.4)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
+
+      get :enchanted, params: {use_route: "raiders/#{raider.id}/enchanted", raider_id: raider.id}
+
+      expect(response).to redirect_to raider_path(raider)
+
+      raider.reload
+      expect(raider.enchanted).to eq false
+      expect(raider.total_points_earned).to eq 0.3
+    end
+
+    it 'requires user to be signed in to perform' do
+      raider = FactoryBot.create(:raider, enchanted: false, total_points_earned: 0.4)
+      admin = FactoryBot.create(:user, admin: true)
+
+      get :enchanted, params: {use_route: "raiders/#{raider.id}/enchanted", raider_id: raider.id}
+
+      expect(response).to redirect_to new_user_session_path
+
+      raider.reload
+      expect(raider.enchanted).to eq false
+      expect(raider.total_points_earned).to eq 0.4
+    end
+
+    it 'requires that user be an admin to perform' do
+      raider = FactoryBot.create(:raider, enchanted: false, total_points_earned: 0.4)
+      non_admin = FactoryBot.create(:user, admin: false)
+      sign_in non_admin
+
+      get :enchanted, params: {use_route: "raiders/#{raider.id}/enchanted", raider_id: raider.id}
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'You do not have the privileges required to do that.'
+
+      raider.reload
+      expect(raider.enchanted).to eq false
+      expect(raider.total_points_earned).to eq 0.4
+    end
+  end
+
+  describe 'raiders#warlock action' do
+    it 'updates a raider without a warlock and adds points' do
+      raider = FactoryBot.create(:raider, warlock: false, total_points_earned: 0.4)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
+
+      get :warlock, params: {use_route: "raiders/#{raider.id}/warlock", raider_id: raider.id}
+
+      expect(response).to redirect_to raider_path(raider)
+
+      raider.reload
+      expect(raider.warlock).to eq true
+      expect(raider.total_points_earned).to eq 0.5
+    end
+
+    it 'updates a raider with a warlock and subtracts points' do
+      raider = FactoryBot.create(:raider, warlock: true, total_points_earned: 0.4)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
+
+      get :warlock, params: {use_route: "raiders/#{raider.id}/warlock", raider_id: raider.id}
+
+      expect(response).to redirect_to raider_path(raider)
+
+      raider.reload
+      expect(raider.warlock).to eq false
+      expect(raider.total_points_earned).to eq 0.3
+    end
+
+    it 'requires user to be signed in to perform action' do
+      raider = FactoryBot.create(:raider, warlock: false, total_points_earned: 0.4)
+      admin = FactoryBot.create(:user, admin: true)
+
+      get :warlock, params: {use_route: "raiders/#{raider.id}/warlock", raider_id: raider.id}
+
+      expect(response).to redirect_to new_user_session_path
+
+      raider.reload
+      expect(raider.warlock).to eq false
+      expect(raider.total_points_earned).to eq 0.4
+    end
+
+    it 'requires user to be admin to perform action' do
+      raider = FactoryBot.create(:raider, warlock: false, total_points_earned: 0.4)
+      non_admin = FactoryBot.create(:user, admin: false)
+      sign_in non_admin
+
+      get :warlock, params: {use_route: "raiders/#{raider.id}/warlock", raider_id: raider.id}
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'You do not have the privileges required to do that.'
+
+      raider.reload
+      expect(raider.warlock).to eq false
+      expect(raider.total_points_earned).to eq 0.4
+    end
+  end
 end

--- a/spec/controllers/winners_controller_spec.rb
+++ b/spec/controllers/winners_controller_spec.rb
@@ -4,18 +4,17 @@ RSpec.describe WinnersController, type: :controller do
   describe 'winners#create action' do
     it 'allows winners to be created and updates total points spend by a raider' do
       raider = FactoryBot.create(:raider, total_points_spent: 0.6, total_points_earned: 5.0)
-      item1 = FactoryBot.create(:item)
-      item2 = FactoryBot.create(:item)
-      winner1 = FactoryBot.create(:winner, raider: raider, item: item2, points_spent: 3.6)
-      winner2 = FactoryBot.create(:winner, item: item1, points_spent: 3.6)
-      user = FactoryBot.create(:user, admin: true)
-      sign_in user
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, ranking: 50, item_id: item.id, raider_id: raider.id)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
       
-      post :create, params: {item_id: item1.id, winner: {raider_id: raider.id, points_spent: 3.6}}
+      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6, priority_id: priority.id}}
 
       expect(response).to redirect_to raider_path(raider)
       winner = Winner.last
       expect(winner.points_spent).to eq 3.6
+      expect(winner.priority).to eq priority
       
       raider.reload      
       expect(raider.total_points_spent).to eq 4.2
@@ -25,8 +24,10 @@ RSpec.describe WinnersController, type: :controller do
     it 'requires user to be signed in' do
       raider = FactoryBot.create(:raider, total_points_spent: 0.6, total_points_earned: 5.0)
       item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, ranking: 50, item_id: item.id, raider_id: raider.id)
+      admin = FactoryBot.create(:user, admin: true)
       
-      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6}}
+      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6, priority_id: priority.id}}
 
       expect(response).to redirect_to new_user_session_path
       expect(Winner.count).to eq 0
@@ -39,10 +40,11 @@ RSpec.describe WinnersController, type: :controller do
     it 'requires user to be administrator' do
       raider = FactoryBot.create(:raider, total_points_spent: 0.6, total_points_earned: 5.0)
       item = FactoryBot.create(:item)
-      user = FactoryBot.create(:user)
-      sign_in user
+      priority = FactoryBot.create(:priority, ranking: 50, item_id: item.id, raider_id: raider.id)
+      non_admin = FactoryBot.create(:user, admin: false)
+      sign_in non_admin
       
-      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6}}
+      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6, priority_id: priority.id}}
 
       expect(response).to redirect_to root_path
       expect(flash[:alert]).to eq 'You do not have the privileges required to do that.'
@@ -53,21 +55,43 @@ RSpec.describe WinnersController, type: :controller do
       expect(raider.total_points_earned).to eq 5.0
     end
 
-    it 'raider can not win same item twice' do
+    it 'allows raider to win same item twice' do
       raider = FactoryBot.create(:raider, total_points_spent: 0.6, total_points_earned: 5.0)
       item = FactoryBot.create(:item)
-      winner = FactoryBot.create(:winner, raider: raider, item: item, points_spent: 3.6)
-      user = FactoryBot.create(:user, admin: true)
-      sign_in user
+      priority = FactoryBot.create(:priority, ranking: 50, item_id: item.id, raider_id: raider.id)
+      winner = FactoryBot.create(:winner, raider_id: raider.id, item_id: item.id, points_spent: 3.6)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
       
-      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6}}
+      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6, priority_id: priority.id}}
+
+      expect(response).to redirect_to raider_path(raider)
+      winner = Winner.last
+      expect(winner.points_spent).to eq 3.6
+      expect(winner.priority).to eq priority
+      
+      raider.reload      
+      expect(raider.total_points_spent).to eq 4.2
+      expect(raider.total_points_earned).to eq 5.0
+    end
+
+    it 'does not allow raider to win on the same priority' do
+      raider = FactoryBot.create(:raider, total_points_spent: 3.6, total_points_earned: 5.0)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, ranking: 50, item_id: item.id, raider_id: raider.id)
+      winner = FactoryBot.create(:winner, raider_id: raider.id, item_id: item.id, points_spent: 3.6, priority_id: priority.id)
+      admin = FactoryBot.create(:user, admin: true)
+      sign_in admin
+      
+      post :create, params: {item_id: item.id, winner: {raider_id: raider.id, points_spent: 3.6, priority_id: priority.id}}
 
       expect(response).to redirect_to item_path(item)
       expect(flash[:alert]).to eq 'There was an error creating this.'
+      
       expect(Winner.count).to eq 1
-
+      
       raider.reload      
-      expect(raider.total_points_spent).to eq 0.6
+      expect(raider.total_points_spent).to eq 3.6
       expect(raider.total_points_earned).to eq 5.0
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Item, type: :model do
     end
   end
 
-  describe 'Item ordered_list_of_priorities method' do
+  describe 'Item phase_3_ordered_list_of_priorities method' do
     it 'returns ordered list of priorities without retired raiders' do
       raider1 = FactoryBot.create(:raider, name: 'Raider 1', which_class: 'Warrior', total_points_earned: 4.0, total_points_spent: 3.0)
       raider2 = FactoryBot.create(:raider, name: 'Raider 2', which_class: 'Warrior', total_points_earned: 5.0, total_points_spent: 3.0)
@@ -67,6 +67,68 @@ RSpec.describe Item, type: :model do
       attendance = FactoryBot.create(:attendance, raider: raider5, points: 0.4, created_at: five_weeks_ago)
 
       expect(item.phase_3_ordered_list_of_priorities).to eq [priority2, priority1, priority3]
+    end
+  end
+
+  describe 'Item phase_5_ordered_list_of_priorities method' do
+    it 'returns list where raider has won first of multiple item occurences but not a second' do
+      raider1 = FactoryBot.create(:raider, name: 'Raider 1', which_class: 'Warrior', total_points_earned: 4.0, total_points_spent: 3.0)
+      raider2 = FactoryBot.create(:raider, name: 'Raider 2', which_class: 'Warrior', total_points_earned: 5.0, total_points_spent: 3.0)
+      raider3 = FactoryBot.create(:raider, name: 'Raider 3', which_class: 'Shaman', total_points_earned: 4.0, total_points_spent: 3.0)
+      item = FactoryBot.create(:item)
+      priority1 = FactoryBot.create(:priority, item: item, raider: raider1, ranking: 50, phase: 5)
+      priority2 = FactoryBot.create(:priority, item: item, raider: raider2, ranking: 50, phase: 5)
+      priority3 = FactoryBot.create(:priority, item: item, raider: raider3, ranking: 49, phase: 5)
+      priority4 = FactoryBot.create(:priority, item: item, raider: raider1, ranking: 47, phase: 5)
+      winner = FactoryBot.create(:winner, item: item, raider: raider1, priority: priority1)
+      five_weeks_ago = Time.now - 50.days
+      attendance = FactoryBot.create(:attendance, raider: raider1, points: 0.4, created_at: five_weeks_ago)
+      attendance = FactoryBot.create(:attendance, raider: raider2, points: 0.4, created_at: five_weeks_ago)
+      attendance = FactoryBot.create(:attendance, raider: raider3, points: 0.4, created_at: five_weeks_ago)
+
+      expect(item.phase_5_ordered_list_of_priorities).to eq [priority2, priority3, priority4]
+    end
+  end
+
+  describe 'Item unlimited? method' do
+    it 'returns true if item is unlimited' do
+      item = FactoryBot.create(:item, classification: 'Unlimited')
+
+      expect(item.unlimited?).to eq true
+    end
+
+    it 'returns false if item is not unlimited' do
+      item = FactoryBot.create(:item, classification: 'Limited')
+
+      expect(item.unlimited?).to eq false
+    end
+  end
+
+  describe 'Item limited? method' do
+    it 'returns true if item is limited' do
+      item = FactoryBot.create(:item, classification: 'Limited')
+
+      expect(item.limited?).to eq true
+    end
+
+    it 'returns false if item is not limited' do
+      item = FactoryBot.create(:item, classification: 'Reserved')
+
+      expect(item.limited?).to eq false
+    end
+  end
+
+  describe 'Item reserved? method' do
+    it 'returns true if item is reserved' do
+      item = FactoryBot.create(:item, classification: 'Reserved')
+
+      expect(item.reserved?).to eq true
+    end
+
+    it 'returns false if item is not reserved' do
+      item = FactoryBot.create(:item, classification: 'Limited')
+
+      expect(item.reserved?).to eq false
     end
   end
 end

--- a/spec/models/priority_spec.rb
+++ b/spec/models/priority_spec.rb
@@ -350,4 +350,69 @@ RSpec.describe Priority, type: :model do
       expect(priority4.valid_priority?(49)).to eq false
     end
   end
+
+  describe 'priority phase_5_total_item_value_for_raider method' do
+    it 'returns full for AQ limited item for raider in there sixth week' do
+      now = Time.now
+      five_weeks_ago = now - 35.days
+      raider = FactoryBot.create(:raider, total_points_earned: 0.2)
+      attendance = FactoryBot.create(:attendance, raider: raider, created_at: five_weeks_ago)
+      item = FactoryBot.create(:item, zone: 'Temple of Ahn\'Qiraj', classification: 'Limited')
+      priority = FactoryBot.create(:priority, raider: raider, item: item, phase: 5)
+
+      expect(priority.phase_5_total_item_value_for_raider).to eq 50.2
+    end
+    
+    it 'returns -1 for AQ limited item for raider in there fifth week' do
+      now = Time.now
+      four_weeks_ago = now - 28.days
+      raider = FactoryBot.create(:raider, total_points_earned: 0.2)
+      attendance = FactoryBot.create(:attendance, raider: raider, created_at: four_weeks_ago)
+      item = FactoryBot.create(:item, zone: 'Temple of Ahn\'Qiraj', classification: 'Limited')
+      priority = FactoryBot.create(:priority, raider: raider, item: item, phase: 5)
+
+      expect(priority.phase_5_total_item_value_for_raider).to eq 49.2
+    end
+
+    it 'returns full for AQ limited item for raider in there sixth week' do
+      now = Time.now
+      three_weeks_ago = now - 21.days
+      raider = FactoryBot.create(:raider, total_points_earned: 0.2)
+      attendance = FactoryBot.create(:attendance, raider: raider, created_at: three_weeks_ago)
+      item = FactoryBot.create(:item, zone: 'Temple of Ahn\'Qiraj', classification: 'Limited')
+      priority = FactoryBot.create(:priority, raider: raider, item: item, phase: 5)
+
+      expect(priority.phase_5_total_item_value_for_raider).to eq 48.2
+    end
+
+    it 'returns full for AQ limited item for raider in there sixth week' do
+      now = Time.now
+      two_weeks_ago = now - 14.days
+      raider = FactoryBot.create(:raider, total_points_earned: 0.2)
+      attendance = FactoryBot.create(:attendance, raider: raider, created_at: two_weeks_ago)
+      item = FactoryBot.create(:item, zone: 'Temple of Ahn\'Qiraj', classification: 'Limited')
+      priority = FactoryBot.create(:priority, raider: raider, item: item, phase: 5)
+
+      expect(priority.phase_5_total_item_value_for_raider).to eq 0
+    end
+
+    it 'returns full value with non primary adjustment for AQ limited item for raider in there sixth week' do
+      now = Time.now
+      five_weeks_ago = now - 35.days
+      raider = FactoryBot.create(:raider, total_points_earned: 0.1)
+      attendance = FactoryBot.create(:attendance, raider: raider, created_at: five_weeks_ago)
+      item = FactoryBot.create(:item, zone: 'Temple of Ahn\'Qiraj', classification: 'Limited', priority: 'Shaman')
+      priority = FactoryBot.create(:priority, raider: raider, item: item, phase: 5)
+
+      expect(priority.phase_5_total_item_value_for_raider).to eq 37.58
+    end
+
+    it 'allows new raider to have point values for unlimited MC item' do
+      raider = FactoryBot.create(:raider)
+      item = FactoryBot.create(:item, zone: 'Molten Core')
+      priority = FactoryBot.create(:priority, raider: raider, item: item, phase: 5)
+
+      expect(priority.phase_5_total_item_value_for_raider).to eq 47.0
+    end
+  end
 end

--- a/spec/models/priority_spec.rb
+++ b/spec/models/priority_spec.rb
@@ -18,6 +18,38 @@ RSpec.describe Priority, type: :model do
       expect(priority.points_worth).to eq 0.4
     end
 
+    it 'returns net points -0.2 if raider is enchanted and has a warlock if raiders has less points than max worth of item' do
+      raider = FactoryBot.create(:raider, total_points_earned: 3.7, enchanted: true, warlock: true)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item)
+      
+      expect(priority.points_worth).to eq 3.5
+    end
+
+    it 'double check points_worth' do
+      raider = FactoryBot.create(:raider, total_points_earned: 2.1, enchanted: true, warlock: true)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 47)
+      
+      expect(priority.points_worth).to eq 1.9
+    end
+
+    it 'triple check points_worth' do
+      raider = FactoryBot.create(:raider, total_points_earned: 2.2, enchanted: true, warlock: true)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item, ranking: 47)
+      
+      expect(priority.points_worth).to eq 2.0
+    end
+
+    it 'returns net points -0.1 if raider is enchanted but has no warlock if raiders has less points than max worth of item' do
+      raider = FactoryBot.create(:raider, total_points_earned: 0.4, enchanted: true, warlock: false)
+      item = FactoryBot.create(:item)
+      priority = FactoryBot.create(:priority, raider: raider, item: item)
+
+      expect(priority.points_worth).to eq 0.3
+    end
+
     it 'returns max worth of 3.6 for bracket 1 item' do
       raider = FactoryBot.create(:raider, total_points_earned: 4.0)
       item = FactoryBot.create(:item)


### PR DESCRIPTION
1. Raiders can delete their own priorities on their lists.
2. Once lists are locked raiders can no longer add items.
3. Added correct penalties for phase 5.
4. Added connection between priorities and winners so list can contain two of the same items.
5. Added enchanted and Warlock for raiders.
6. Fixed display bug for non admins of complete lists of attendances and winnings.
7. Changed attendance input from multiple buttons with values to an input field where attendance can be set.