### PR TITLE
Lists can be seen by approved raiders

### DIFF
--- a/app/controllers/raids_controller.rb
+++ b/app/controllers/raids_controller.rb
@@ -72,7 +72,7 @@ class RaidsController < ApplicationController
     healers_count = 0
     damage_dealers = 0
     signups = Signup.where(raid_id: raid)
-    if raid.zg?  
+    if raid.zg? || raid.aq?
       signups.each do |signup|
         raider = Raider.find(signup.user.raider_id)
 

--- a/app/models/raid.rb
+++ b/app/models/raid.rb
@@ -9,6 +9,15 @@ class Raid < ApplicationRecord
     end
     return false
   end
+
+  def aq? 
+    name = self.name.downcase.split('')
+    if name.include? 'a'
+      return true if name.include? 'q'
+      return false
+    end
+    return false
+  end
   
   validates :name, presence: true, length: {minimum: 2, maximum: 25}
   validates :start_time, presence: true

--- a/app/views/items/_p5_ordered_list_of_priorities.html.erb
+++ b/app/views/items/_p5_ordered_list_of_priorities.html.erb
@@ -6,7 +6,11 @@
 </div>
 <% @item.phase_5_ordered_list_of_priorities.each do |priority| %>
   <div class="row">
-    <div class="col-3"><h5><%= link_to priority.raider.name, raider_path(priority.raider_id) %> - <%= priority.phase_5_total_item_value_for_raider %></h5></div>
+    <% if current_user.try(:approved_raider) %>
+      <div class="col-3"><h5><%= link_to priority.raider.name, raider_path(priority.raider_id) %> - <%= priority.phase_5_total_item_value_for_raider %></h5></div>
+    <% else %>
+      <div class="col-3"><h5><%= link_to priority.raider.name, raider_path(priority.raider_id) %></h5></div>
+    <% end %>
     <% if current_user.try(:admin?) %>
       <div class="col-3">
         <button data-raider-id="<%= priority.raider.id %>" data-raider-name="<%= priority.raider.name %>" data-item-id="<%= @item.id %>" data-priority-id="<%= priority.id %>" data-points-spent="<%= priority.points_worth %>" class="btn btn-secondary create-winner btn-sm">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,21 +30,18 @@
   <% end %>
   <br />
   
+  <hr class="grey">
+  <%= render partial: 'p5_ordered_list_of_priorities' %>
+  
   <% if @item.phase_3? %>
-    <%= render partial: 'p3_ordered_list_of_priorities' %>
+    <% render partial: 'p3_ordered_list_of_priorities' %>
   <% end %>  
     
   <br />
 
   <% if @item.phase_3? %>
-    <%= render partial: 'p3_priority_assignment' %>
+    <% render partial: 'p3_priority_assignment' %>
   <% end %>
-
-  <% if current_user.try(:admin?)  %>
-    <hr class="grey">
-    <%= render partial: 'p5_ordered_list_of_priorities' %>
-  <% end %>  
-  
 </div>
 
 <script type="text/javascript">

--- a/app/views/raiders/show.html.erb
+++ b/app/views/raiders/show.html.erb
@@ -114,7 +114,7 @@
   <% end %>
   
   <% if current_user && current_user == @raider.user || current_user.try(:approved_raider?) %>
-    <%= render partial: 'phase_3_loot_list' %>
+    <% render partial: 'phase_3_loot_list' %>
   <% end %>
 
 </div>

--- a/spec/controllers/raids_controller_spec.rb
+++ b/spec/controllers/raids_controller_spec.rb
@@ -189,6 +189,46 @@ RSpec.describe RaidsController, type: :controller do
       expect(assigns(:organized_signups)[4].count).to eq 1
     end
 
+    it 'In AQ 3rd tank becomes DPS 6th healer becomes standby' do
+      raid = FactoryBot.create(:raid, name: 'AQ - optionalz')
+      raider1 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider2 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider3 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')
+      raider4 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider5 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider6 = FactoryBot.create(:raider, which_class: 'Shaman', role: 'Healer')
+      raider7 = FactoryBot.create(:raider, which_class: 'Priest', role: 'Healer')
+      raider8 = FactoryBot.create(:raider, which_class: 'Priest', role: 'Healer')
+      raider9 = FactoryBot.create(:raider, which_class: 'Druid', role: 'Healer')
+      user1 = FactoryBot.create(:user, raider_id: raider1.id)
+      user2 = FactoryBot.create(:user, raider_id: raider2.id)
+      user3 = FactoryBot.create(:user, raider_id: raider3.id)
+      user4 = FactoryBot.create(:user, raider_id: raider4.id)
+      user5 = FactoryBot.create(:user, raider_id: raider5.id)
+      user6 = FactoryBot.create(:user, raider_id: raider6.id)
+      user7 = FactoryBot.create(:user, raider_id: raider7.id)
+      user8 = FactoryBot.create(:user, raider_id: raider8.id)
+      user9 = FactoryBot.create(:user, raider_id: raider9.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user1.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user2.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user3.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user4.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user5.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user6.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user7.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user8.id)
+      signup = FactoryBot.create(:signup, raid_id: raid.id, user_id: user9.id)
+      
+      get :show, params: { id: raid.id}
+      
+      expect(response).to have_http_status(:success)
+      expect(assigns(:raid)).to eq(raid)
+      expect(assigns(:organized_signups)[0].count).to eq 2
+      expect(assigns(:organized_signups)[2].count).to eq 1
+      expect(assigns(:organized_signups)[1].count).to eq 5
+      expect(assigns(:organized_signups)[4].count).to eq 1
+    end
+
     it 'In non ZG no limits to assignments' do
       raid = FactoryBot.create(:raid, name: 'Another go')
       raider1 = FactoryBot.create(:raider, which_class: 'Warrior', role: 'Tank')


### PR DESCRIPTION
1. AQ ranked lists can be seen by approved raiders.
2. AQ raids on the Calendar will behave like ZG raids and put signups past 20 in a standby.
3. Added test for behavior of AQ raids.
4. Hid all lists relating with phase 3 on both item and raiders show page.
